### PR TITLE
refactor: load worker via Vite import

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -42,36 +42,17 @@ const App: React.FC = () => {
 
   useEffect(() => {
     let worker: Worker | null = null;
-    let objectUrl: string | null = null;
-
-    const createWorker = async () => {
-        try {
-            const workerScriptResponse = await fetch('./services/missionAnalysis.worker.ts');
-            if (!workerScriptResponse.ok) {
-                throw new Error(`Failed to fetch worker script: ${workerScriptResponse.statusText}`);
-            }
-            const workerScript = await workerScriptResponse.text();
-            const blob = new Blob([workerScript], { type: 'application/javascript' });
-            objectUrl = URL.createObjectURL(blob);
-            worker = new Worker(objectUrl, { type: 'module' });
-            setMissionAnalysisWorker(worker);
-        } catch (error) {
-            console.error("Failed to create mission analysis worker:", error);
-            dispatch({ type: 'ANALYSIS_ERROR', payload: { message: `Could not initialize analysis engine: ${(error as Error).message}` } });
-        }
-    };
-
-    createWorker();
-
+    try {
+      worker = new Worker(new URL('./services/missionAnalysis.worker.ts', import.meta.url), { type: 'module' });
+      setMissionAnalysisWorker(worker);
+    } catch (error) {
+      console.error('Failed to create mission analysis worker:', error);
+      dispatch({ type: 'ANALYSIS_ERROR', payload: { message: `Could not initialize analysis engine: ${(error as Error).message}` } });
+    }
     return () => {
-        if (worker) {
-            worker.terminate();
-        }
-        if (objectUrl) {
-            URL.revokeObjectURL(objectUrl);
-        }
+      worker?.terminate();
     };
-  }, []);
+  }, [dispatch]);
 
   useEffect(() => {
     if (!missionAnalysisWorker) return;


### PR DESCRIPTION
## Summary
- initialize mission analysis worker using Vite's `new URL` pattern
- remove manual fetch/blob setup for worker

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e93caedd48328aa6e5a3ffc510ab3