### PR TITLE
Add base index.css and test for stylesheet link

### DIFF
--- a/index.css
+++ b/index.css
@@ -1,0 +1,14 @@
+/* Base styles */
+html, body, #root {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: system-ui, sans-serif;
+  line-height: 1.5;
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node tests/index-css.test.js"
   },
   "dependencies": {
     "react-dom": "^18.2.0",

--- a/tests/index-css.test.js
+++ b/tests/index-css.test.js
@@ -1,0 +1,11 @@
+import { strict as assert } from 'node:assert';
+import fs from 'node:fs';
+
+assert.ok(fs.existsSync('index.css'), 'index.css should exist');
+const css = fs.readFileSync('index.css', 'utf8');
+assert.ok(css.trim().length > 0, 'index.css should not be empty');
+
+const html = fs.readFileSync('index.html', 'utf8');
+assert.ok(html.includes('<link rel="stylesheet" href="/index.css">'), 'index.html should reference index.css');
+
+console.log('index.css link and content test passed.');


### PR DESCRIPTION
## Summary
- add base stylesheet at project root
- ensure index.css is linked in HTML via simple node test
- expose test through npm script

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e93cc68cc832891d8e68a86d6f7f0