### PR TITLE
chore: remove importmap to rely on local node modules

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,19 +93,8 @@
       }
 
     </style>
-  <script type="importmap">
-{
-  "imports": {
-    "react-dom/": "https://esm.sh/react-dom@^18.2.0/",
-    "react/": "https://esm.sh/react@^18.2.0/",
-    "react": "https://esm.sh/react@^18.2.0",
-    "@google/genai": "https://esm.sh/@google/genai@^1.10.0",
-    "pigeon-maps": "https://esm.sh/pigeon-maps@^0.22.1"
-  }
-}
-</script>
-<link rel="stylesheet" href="/index.css">
-</head>
+  <link rel="stylesheet" href="/index.css">
+  </head>
   <body class="bg-slate-100">
     <div id="root"></div>
     <script type="module" src="/index.tsx"></script>


### PR DESCRIPTION
## Summary
- remove CDN import map from `index.html` so React and other deps resolve from local `node_modules`

## Testing
- `npm test`
- `npm run build`
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_689e996d1b7c8328a4ccab0fc19e5ecb