### PR TITLE
Add worker initialization fallback and tests

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -39,6 +39,7 @@ const App: React.FC = () => {
 
   // --- Mission Analysis Worker ---
   const [missionAnalysisWorker, setMissionAnalysisWorker] = useState<Worker | null>(null);
+  const [workerInitFailed, setWorkerInitFailed] = useState(false);
 
   useEffect(() => {
     let worker: Worker | null = null;
@@ -48,6 +49,7 @@ const App: React.FC = () => {
     } catch (error) {
       console.error('Failed to create mission analysis worker:', error);
       dispatch({ type: 'ANALYSIS_ERROR', payload: { message: `Could not initialize analysis engine: ${(error as Error).message}` } });
+      setWorkerInitFailed(true);
     }
     return () => {
       worker?.terminate();
@@ -232,6 +234,11 @@ const App: React.FC = () => {
         />
         {!isSidebarCollapsed && <ResizeHandle onMouseDown={handleMouseDown} />}
         <main className="flex-1 h-full min-w-0 relative">
+          {workerInitFailed && (
+            <div className="absolute inset-0 flex items-center justify-center bg-red-100 text-red-800 z-10">
+              Analysis engine unavailable.
+            </div>
+          )}
           <MapComponent
             ref={mapRef}
             missionAnalysisWorker={missionAnalysisWorker}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "node tests/index-css.test.js && node tests/mission-analysis-worker.test.js"
+    "test": "node tests/index-css.test.js && node tests/mission-analysis-worker.test.js && node --loader ./tests/ts-loader.mjs ./tests/worker-fallback.test.js"
   },
   "dependencies": {
     "react-dom": "^18.2.0",
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@types/node": "^22.14.0",
     "typescript": "~5.8.2",
-    "vite": "^6.2.0"
+    "vite": "^6.2.0",
+    "jsdom": "^24.0.0"
   }
 }

--- a/tests/ts-loader.mjs
+++ b/tests/ts-loader.mjs
@@ -5,7 +5,11 @@ export async function resolve(specifier, context, defaultResolve) {
   try {
     return await defaultResolve(specifier, context, defaultResolve);
   } catch (err) {
-    if (specifier.startsWith('.') && !specifier.endsWith('.js') && !specifier.endsWith('.ts')) {
+    if (specifier.startsWith('.') && specifier.endsWith('.tsx')) {
+      const url = new URL(specifier, context.parentURL).href;
+      return { url, shortCircuit: true };
+    }
+    if (specifier.startsWith('.') && !specifier.endsWith('.js') && !specifier.endsWith('.ts') && !specifier.endsWith('.tsx')) {
       const url = new URL(specifier + '.ts', context.parentURL).href;
       return { url, shortCircuit: true };
     }
@@ -14,10 +18,14 @@ export async function resolve(specifier, context, defaultResolve) {
 }
 
 export async function load(url, context, defaultLoad) {
-  if (url.endsWith('.ts')) {
+  if (url.endsWith('.ts') || url.endsWith('.tsx')) {
     const source = await readFile(new URL(url));
     const { outputText } = ts.transpileModule(source.toString(), {
-      compilerOptions: { module: ts.ModuleKind.ES2020, target: ts.ScriptTarget.ES2020 }
+      compilerOptions: {
+        module: ts.ModuleKind.ES2020,
+        target: ts.ScriptTarget.ES2020,
+        jsx: ts.JsxEmit.ReactJSX
+      }
     });
     return { format: 'module', source: outputText, shortCircuit: true };
   }

--- a/tests/worker-fallback.test.js
+++ b/tests/worker-fallback.test.js
@@ -1,0 +1,34 @@
+import { strict as assert } from 'node:assert';
+import { JSDOM } from 'jsdom';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from '../App.tsx';
+
+// Setup a DOM environment
+const dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
+  url: 'http://localhost/'
+});
+
+globalThis.window = dom.window;
+globalThis.document = dom.window.document;
+globalThis.navigator = dom.window.navigator;
+
+// Make Worker throw during construction
+globalThis.Worker = class {
+  constructor() {
+    throw new Error('fail');
+  }
+};
+
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(React.createElement(App));
+
+// Allow effects to run
+await new Promise((resolve) => setTimeout(resolve, 0));
+
+const text = container.textContent || '';
+assert.ok(text.includes('Analysis engine unavailable.'), 'Fallback message should render');
+
+console.log('worker fallback render test passed.');
+


### PR DESCRIPTION
## Summary
- flag worker initialization failures to show an on-screen fallback message
- extend test loader for TSX/JSX support
- add unit test covering worker failure fallback rendering

## Testing
- `npm test` *(fails: Cannot find package 'jsdom' due to missing dependency)*

------
https://chatgpt.com/codex/tasks/task_e_689e996e0ef483289cf91d71b08e2775