### PR TITLE
Add initial App rendering test

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "node tests/index-css.test.js && node tests/mission-analysis-worker.test.js"
+    "test": "node tests/index-css.test.js && node tests/mission-analysis-worker.test.js && vitest run tests/app-render.test.tsx --environment jsdom"
   },
   "dependencies": {
     "react-dom": "^18.2.0",
@@ -18,6 +18,10 @@
   "devDependencies": {
     "@types/node": "^22.14.0",
     "typescript": "~5.8.2",
-    "vite": "^6.2.0"
+    "vite": "^6.2.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.4.2",
+    "vitest": "^1.6.0",
+    "jsdom": "^24.0.0"
   }
 }

--- a/tests/app-render.test.tsx
+++ b/tests/app-render.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import App from '../App';
+
+class WorkerMock {
+  constructor(_url: string) {}
+  postMessage() {}
+  terminate() {}
+}
+
+// @ts-ignore
+global.Worker = WorkerMock;
+
+describe('App component', () => {
+  it('renders Sidebar and MapComponent', () => {
+    render(<App />);
+    expect(screen.getByRole('complementary')).toBeInTheDocument();
+    expect(screen.getByLabelText('Analyze Scenario')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add test that renders App and checks Sidebar and MapControls
- wire up vitest in test script and add testing libraries

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e996eac708328974072702fafef57