### PR TITLE
refactor: modularize mission worker, sidebar, and time controls

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,19 +1,16 @@
 
-import React, { useState, useCallback, useRef, useEffect, useReducer } from 'react';
-import { Sidebar } from './components/Sidebar';
+import React, { useState, useRef, useEffect, useReducer } from 'react';
 import { MapComponent } from './components/Map';
-import { ResizeHandle } from './components/ResizeHandle';
 import { ContextMenu } from './components/ContextMenu';
-import type { LibraryEntity, MissionThread } from './types';
+import type { LibraryEntity } from './types';
 import { TimeControls } from './components/TimeControls';
 import { MissionAnalysisOverlay } from './components/MissionAnalysisOverlay';
 import { AppContext, initialState } from './state/appState';
 import { appReducer } from './state/appReducer';
 import { EntityCreatorModal } from './components/EntityCreatorModal';
+import { SidebarLayout } from './components/SidebarLayout';
+import { useMissionAnalysisWorker } from './hooks/useMissionAnalysisWorker';
 
-const MIN_SIDEBAR_WIDTH = 320; // px
-const MAX_SIDEBAR_WIDTH = 800; // px
-const COLLAPSED_SIDEBAR_WIDTH = 64; // px
 const LOCAL_STORAGE_KEY = 'opscanvas-library';
 
 const App: React.FC = () => {
@@ -21,55 +18,13 @@ const App: React.FC = () => {
   const [state, dispatch] = useReducer(appReducer, initialState);
 
   // --- Local UI State ---
-  const [sidebarWidth, setSidebarWidth] = useState(384);
-  const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
-  const savedSidebarWidth = useRef(sidebarWidth);
-  const isResizingRef = useRef(false);
-  
   const [isCreatorModalOpen, setIsCreatorModalOpen] = useState(false);
   const [editingEntity, setEditingEntity] = useState<LibraryEntity | null>(null);
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; instanceId: string; } | null>(null);
-
-  const [timeMultiplier, setTimeMultiplier] = useState(1);
-  const [isPaused, setIsPaused] = useState(true);
-  const animationFrameId = useRef<number | null>(null);
-  const lastFrameTime = useRef<number>(Date.now());
-  
   const mapRef = useRef<{ centerOn: (coords: [number, number]) => void }>(null);
 
   // --- Mission Analysis Worker ---
-  const [missionAnalysisWorker, setMissionAnalysisWorker] = useState<Worker | null>(null);
-  const [workerInitFailed, setWorkerInitFailed] = useState(false);
-
-  useEffect(() => {
-    let worker: Worker | null = null;
-    try {
-      worker = new Worker(new URL('./services/missionAnalysis.worker.ts', import.meta.url), { type: 'module' });
-      setMissionAnalysisWorker(worker);
-    } catch (error) {
-      console.error('Failed to create mission analysis worker:', error);
-      dispatch({ type: 'ANALYSIS_ERROR', payload: { message: `Could not initialize analysis engine: ${(error as Error).message}` } });
-      setWorkerInitFailed(true);
-    }
-    return () => {
-      worker?.terminate();
-    };
-  }, [dispatch]);
-
-  useEffect(() => {
-    if (!missionAnalysisWorker) return;
-
-    missionAnalysisWorker.onmessage = (event: MessageEvent<MissionThread[] | { error: string }>) => {
-      const data = event.data;
-      if (data && typeof data === 'object' && 'error' in data) {
-        dispatch({ type: 'ANALYSIS_ERROR', payload: { message: `Worker error: ${data.error}` } });
-      } else {
-        dispatch({ type: 'FINISH_ANALYSIS', payload: { threads: data as MissionThread[], placedEntities: state.placedEntities } });
-      }
-    };
-    missionAnalysisWorker.onerror = (error) => dispatch({ type: 'ANALYSIS_ERROR', payload: { message: `Worker failed: ${error.message}` } });
-    
-  }, [missionAnalysisWorker, state.placedEntities, dispatch]);
+  const { missionAnalysisWorker, workerInitFailed } = useMissionAnalysisWorker(state, dispatch);
 
   // --- PERSISTENCE ---
   useEffect(() => {
@@ -108,176 +63,77 @@ const App: React.FC = () => {
   const handleEntityRightClick = (instanceId: string, position: {x: number, y: number}) => {
     setContextMenu({ ...position, instanceId });
   };
-
-  // --- Re-run analysis automatically if it's already visible and a system is disabled/enabled
   useEffect(() => {
-    if (state.isAnalysisOverlayVisible && missionAnalysisWorker) {
-      dispatch({ type: 'START_ANALYSIS' });
-      missionAnalysisWorker.postMessage({
-        entities: state.placedEntities,
-        disabledSystemIds: state.disabledSystemIds
-      });
-    }
-  }, [state.disabledSystemIds, state.isAnalysisOverlayVisible, state.placedEntities, missionAnalysisWorker, dispatch]);
-
-
-  // --- Time & Animation Loop ---
-  const handleTogglePause = useCallback(() => setIsPaused(p => !p), []);
-  const handleSetMultiplier = useCallback((speed: number) => {
-    setTimeMultiplier(speed);
-    setIsPaused(false);
-  }, []);
-
-  useEffect(() => {
-    if (isPaused) {
-      if (animationFrameId.current) cancelAnimationFrame(animationFrameId.current);
-      animationFrameId.current = null;
-      return;
-    }
-    const loop = () => {
-      const now = Date.now();
-      const deltaTime = now - lastFrameTime.current;
-      lastFrameTime.current = now;
-      const scaledDeltaTime = deltaTime * timeMultiplier;
-      dispatch({ type: 'TICK', payload: { scaledDeltaTime } });
-      animationFrameId.current = requestAnimationFrame(loop);
-    };
-    lastFrameTime.current = Date.now();
-    animationFrameId.current = requestAnimationFrame(loop);
-    return () => { if (animationFrameId.current) cancelAnimationFrame(animationFrameId.current) };
-  }, [isPaused, timeMultiplier, dispatch]);
-  
-  
-  // --- Global Event Listeners & Sidebar resizing ---
-  const toggleSidebarCollapse = useCallback(() => {
-    setIsSidebarCollapsed(prevCollapsed => {
-        const isNowCollapsing = !prevCollapsed;
-        setSidebarWidth(isNowCollapsing ? COLLAPSED_SIDEBAR_WIDTH : savedSidebarWidth.current);
-        return isNowCollapsing;
-    });
-  }, []);
-
-  useEffect(() => {
-      if ((state.selectedEntityId || state.multiSelectedIds.length > 0) && isSidebarCollapsed) {
-          toggleSidebarCollapse();
-      }
-  }, [state.selectedEntityId, state.multiSelectedIds, isSidebarCollapsed, toggleSidebarCollapse]);
-  
-  const handleMouseDown = useCallback((e: React.MouseEvent) => {
-    if (isSidebarCollapsed) return;
-    e.preventDefault();
-    isResizingRef.current = true;
-  }, [isSidebarCollapsed]);
-
-  const handleMouseUp = useCallback(() => { isResizingRef.current = false; }, []);
-  
-  const handleMouseMove = useCallback((e: MouseEvent) => {
-    if (!isResizingRef.current || isSidebarCollapsed) return;
-    e.preventDefault();
-    let newWidth = Math.max(MIN_SIDEBAR_WIDTH, Math.min(e.clientX, MAX_SIDEBAR_WIDTH));
-    setSidebarWidth(newWidth);
-    savedSidebarWidth.current = newWidth;
-  }, [isSidebarCollapsed]);
-
-  useEffect(() => {
-    const handleGlobalMouseMove = (e: MouseEvent) => { if (isResizingRef.current) handleMouseMove(e); }
-    const handleGlobalClick = () => { if (contextMenu) setContextMenu(null); }
+    const handleGlobalClick = () => { if (contextMenu) setContextMenu(null); };
     const handleEsc = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         if (contextMenu) setContextMenu(null);
         if (state.movingEntityId || state.linkingState || state.plottingWaypointsFor || state.targetingState || state.placingEntityId) {
-            dispatch({ type: 'CANCEL_INTERACTION' });
+          dispatch({ type: 'CANCEL_INTERACTION' });
         }
         if (state.multiSelectedIds.length > 0 || state.selectedEntityId) dispatch({ type: 'CLEAR_SELECTION' });
         if (state.isAnalysisOverlayVisible) dispatch({ type: 'CLOSE_ANALYSIS' });
         if (isCreatorModalOpen) setIsCreatorModalOpen(false);
       }
     };
-     const handleKey = (e: KeyboardEvent) => {
-        if (e.code === 'Space' && (e.target as HTMLElement).tagName !== 'INPUT' && (e.target as HTMLElement).tagName !== 'TEXTAREA') {
-            e.preventDefault();
-            handleTogglePause();
-        }
-    };
-
-    window.addEventListener('mousemove', handleGlobalMouseMove);
-    window.addEventListener('mouseup', handleMouseUp);
     window.addEventListener('click', handleGlobalClick);
     window.addEventListener('keydown', handleEsc);
-    window.addEventListener('keydown', handleKey);
     return () => {
-      window.removeEventListener('mousemove', handleGlobalMouseMove);
-      window.removeEventListener('mouseup', handleMouseUp);
       window.removeEventListener('click', handleGlobalClick);
       window.removeEventListener('keydown', handleEsc);
-      window.removeEventListener('keydown', handleKey);
     };
-  }, [handleMouseMove, handleMouseUp, contextMenu, state, handleTogglePause, isCreatorModalOpen]);
+  }, [contextMenu, state, dispatch, isCreatorModalOpen]);
 
-
-  const mainClasses = [
-      'flex h-screen font-sans text-slate-800 bg-slate-100 overflow-hidden',
-      (isResizingRef.current && !isSidebarCollapsed) ? 'cursor-col-resize select-none' : '',
-      state.movingEntityId || state.targetingState ? 'cursor-crosshair' : '',
-      state.placingEntityId ? 'cursor-copy' : ''
+  const cursorClasses = [
+    state.movingEntityId || state.targetingState ? 'cursor-crosshair' : '',
+    state.placingEntityId ? 'cursor-copy' : ''
   ].join(' ');
 
   return (
     <AppContext.Provider value={{ state, dispatch }}>
-      <div className={mainClasses}>
-        <Sidebar
-          width={sidebarWidth}
-          isCollapsed={isSidebarCollapsed}
-          onToggleCollapse={toggleSidebarCollapse}
-          onNewEntity={handleNewEntity}
-          onEditEntity={handleEditEntity}
+      <SidebarLayout
+        onNewEntity={handleNewEntity}
+        onEditEntity={handleEditEntity}
+        className={cursorClasses}
+      >
+        {workerInitFailed && (
+          <div className="absolute inset-0 flex items-center justify-center bg-red-100 text-red-800 z-10">
+            Analysis engine unavailable.
+          </div>
+        )}
+        <MapComponent
+          ref={mapRef}
+          missionAnalysisWorker={missionAnalysisWorker}
+          onEntityRightClick={handleEntityRightClick}
         />
-        {!isSidebarCollapsed && <ResizeHandle onMouseDown={handleMouseDown} />}
-        <main className="flex-1 h-full min-w-0 relative">
-          {workerInitFailed && (
-            <div className="absolute inset-0 flex items-center justify-center bg-red-100 text-red-800 z-10">
-              Analysis engine unavailable.
-            </div>
-          )}
-          <MapComponent
-            ref={mapRef}
-            missionAnalysisWorker={missionAnalysisWorker}
-            onEntityRightClick={handleEntityRightClick}
-          />
-          {state.isAnalysisOverlayVisible && <MissionAnalysisOverlay />}
-          <TimeControls
-            isPaused={isPaused}
-            timeMultiplier={timeMultiplier}
-            onTogglePause={handleTogglePause}
-            onSetMultiplier={handleSetMultiplier}
-          />
-        </main>
-        {isCreatorModalOpen && (
-          <EntityCreatorModal
-            isOpen={isCreatorModalOpen}
-            onClose={() => setIsCreatorModalOpen(false)}
-            onSave={handleSaveEntity}
-            entity={editingEntity}
-          />
-        )}
-        {contextMenu && (
-            <ContextMenu
-                x={contextMenu.x} y={contextMenu.y}
-                onClose={() => setContextMenu(null)}
-                actions={{
-                    onMove: () => dispatch({ type: 'START_MOVING_ENTITY', payload: contextMenu.instanceId }),
-                    onPlotWaypoints: () => dispatch({ type: 'START_PLOTTING_WAYPOINTS', payload: contextMenu.instanceId }),
-                    onCenter: () => {
-                        const entity = state.placedEntities.find(e => e.instanceId === contextMenu.instanceId);
-                        if(entity) mapRef.current?.centerOn(entity.currentPosition || entity.position);
-                    },
-                    onDuplicate: () => dispatch({ type: 'DUPLICATE_ENTITY', payload: contextMenu.instanceId }),
-                    onViewDetails: () => dispatch({ type: 'SELECT_ENTITY', payload: { instanceId: contextMenu.instanceId, isShift: false } }),
-                    onDelete: () => dispatch({ type: 'REMOVE_ENTITY_FROM_MAP', payload: contextMenu.instanceId }),
-                }}
-            />
-        )}
-      </div>
+        {state.isAnalysisOverlayVisible && <MissionAnalysisOverlay />}
+        <TimeControls />
+      </SidebarLayout>
+      {isCreatorModalOpen && (
+        <EntityCreatorModal
+          isOpen={isCreatorModalOpen}
+          onClose={() => setIsCreatorModalOpen(false)}
+          onSave={handleSaveEntity}
+          entity={editingEntity}
+        />
+      )}
+      {contextMenu && (
+        <ContextMenu
+          x={contextMenu.x} y={contextMenu.y}
+          onClose={() => setContextMenu(null)}
+          actions={{
+            onMove: () => dispatch({ type: 'START_MOVING_ENTITY', payload: contextMenu.instanceId }),
+            onPlotWaypoints: () => dispatch({ type: 'START_PLOTTING_WAYPOINTS', payload: contextMenu.instanceId }),
+            onCenter: () => {
+              const entity = state.placedEntities.find(e => e.instanceId === contextMenu.instanceId);
+              if (entity) mapRef.current?.centerOn(entity.currentPosition || entity.position);
+            },
+            onDuplicate: () => dispatch({ type: 'DUPLICATE_ENTITY', payload: contextMenu.instanceId }),
+            onViewDetails: () => dispatch({ type: 'SELECT_ENTITY', payload: { instanceId: contextMenu.instanceId, isShift: false } }),
+            onDelete: () => dispatch({ type: 'REMOVE_ENTITY_FROM_MAP', payload: contextMenu.instanceId }),
+          }}
+        />
+      )}
     </AppContext.Provider>
   );
 };

--- a/components/SidebarLayout.tsx
+++ b/components/SidebarLayout.tsx
@@ -1,0 +1,78 @@
+import React, { useState, useRef, useCallback, useEffect } from 'react';
+import { Sidebar } from './Sidebar';
+import { ResizeHandle } from './ResizeHandle';
+import type { LibraryEntity } from '../types';
+
+const MIN_SIDEBAR_WIDTH = 320; // px
+const MAX_SIDEBAR_WIDTH = 800; // px
+const COLLAPSED_SIDEBAR_WIDTH = 64; // px
+
+interface SidebarLayoutProps {
+  onNewEntity: () => void;
+  onEditEntity: (entity: LibraryEntity) => void;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export const SidebarLayout: React.FC<SidebarLayoutProps> = ({ onNewEntity, onEditEntity, children, className = '' }) => {
+  const [sidebarWidth, setSidebarWidth] = useState(384);
+  const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
+  const savedSidebarWidth = useRef(sidebarWidth);
+  const isResizingRef = useRef(false);
+
+  const toggleSidebarCollapse = useCallback(() => {
+    setIsSidebarCollapsed(prev => {
+      const collapsing = !prev;
+      setSidebarWidth(collapsing ? COLLAPSED_SIDEBAR_WIDTH : savedSidebarWidth.current);
+      return collapsing;
+    });
+  }, []);
+
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    if (isSidebarCollapsed) return;
+    e.preventDefault();
+    isResizingRef.current = true;
+  }, [isSidebarCollapsed]);
+
+  const handleMouseUp = useCallback(() => { isResizingRef.current = false; }, []);
+
+  const handleMouseMove = useCallback((e: MouseEvent) => {
+    if (!isResizingRef.current || isSidebarCollapsed) return;
+    e.preventDefault();
+    const newWidth = Math.max(MIN_SIDEBAR_WIDTH, Math.min(e.clientX, MAX_SIDEBAR_WIDTH));
+    setSidebarWidth(newWidth);
+    savedSidebarWidth.current = newWidth;
+  }, [isSidebarCollapsed]);
+
+  useEffect(() => {
+    const handleGlobalMouseMove = (e: MouseEvent) => { if (isResizingRef.current) handleMouseMove(e); };
+    window.addEventListener('mousemove', handleGlobalMouseMove);
+    window.addEventListener('mouseup', handleMouseUp);
+    return () => {
+      window.removeEventListener('mousemove', handleGlobalMouseMove);
+      window.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [handleMouseMove, handleMouseUp]);
+
+  const rootClasses = [
+    'flex h-screen font-sans text-slate-800 bg-slate-100 overflow-hidden',
+    (isResizingRef.current && !isSidebarCollapsed) ? 'cursor-col-resize select-none' : '',
+    className
+  ].join(' ');
+
+  return (
+    <div className={rootClasses}>
+      <Sidebar
+        width={sidebarWidth}
+        isCollapsed={isSidebarCollapsed}
+        onToggleCollapse={toggleSidebarCollapse}
+        onNewEntity={onNewEntity}
+        onEditEntity={onEditEntity}
+      />
+      {!isSidebarCollapsed && <ResizeHandle onMouseDown={handleMouseDown} />}
+      <main className="flex-1 h-full min-w-0 relative">
+        {children}
+      </main>
+    </div>
+  );
+};

--- a/components/TimeControls.tsx
+++ b/components/TimeControls.tsx
@@ -1,21 +1,15 @@
 
 import React from 'react';
 import { TimePlayIcon, TimePauseIcon } from './icons';
-
-interface TimeControlsProps {
-  isPaused: boolean;
-  timeMultiplier: number;
-  onTogglePause: () => void;
-  onSetMultiplier: (speed: number) => void;
-}
+import { useTimeControls } from '../hooks/useTimeControls';
 
 const SPEEDS = [1, 2, 4, 8, 16];
-
-export const TimeControls: React.FC<TimeControlsProps> = ({ isPaused, timeMultiplier, onTogglePause, onSetMultiplier }) => {
+export const TimeControls: React.FC = () => {
+  const { isPaused, timeMultiplier, togglePause, setMultiplier } = useTimeControls();
   return (
     <div className="absolute bottom-4 left-1/2 -translate-x-1/2 bg-white/80 backdrop-blur-sm rounded-lg shadow-lg z-10 flex items-center p-1.5 space-x-2 animate-fade-in">
       <button
-        onClick={onTogglePause}
+        onClick={togglePause}
         className="w-10 h-10 flex items-center justify-center rounded-md bg-slate-200 hover:bg-slate-300 text-slate-700 transition-colors"
         aria-label={isPaused ? "Play" : "Pause"}
       >
@@ -25,7 +19,7 @@ export const TimeControls: React.FC<TimeControlsProps> = ({ isPaused, timeMultip
         {SPEEDS.map(speed => (
           <button
             key={speed}
-            onClick={() => onSetMultiplier(speed)}
+            onClick={() => setMultiplier(speed)}
             className={`px-3 py-1.5 rounded-md text-sm font-bold transition-colors w-12 ${
               !isPaused && timeMultiplier === speed
                 ? 'bg-sky-500 text-white shadow'

--- a/hooks/useMissionAnalysisWorker.ts
+++ b/hooks/useMissionAnalysisWorker.ts
@@ -1,0 +1,53 @@
+import { useState, useEffect } from 'react';
+import type { AppState, AppAction } from '../state/appState';
+import type { MissionThread } from '../types';
+
+export const useMissionAnalysisWorker = (
+  state: AppState,
+  dispatch: React.Dispatch<AppAction>
+) => {
+  const [missionAnalysisWorker, setMissionAnalysisWorker] = useState<Worker | null>(null);
+  const [workerInitFailed, setWorkerInitFailed] = useState(false);
+
+  useEffect(() => {
+    let worker: Worker | null = null;
+    try {
+      worker = new Worker(new URL('../services/missionAnalysis.worker.ts', import.meta.url), { type: 'module' });
+      setMissionAnalysisWorker(worker);
+    } catch (error) {
+      console.error('Failed to create mission analysis worker:', error);
+      dispatch({ type: 'ANALYSIS_ERROR', payload: { message: `Could not initialize analysis engine: ${(error as Error).message}` } });
+      setWorkerInitFailed(true);
+    }
+    return () => {
+      worker?.terminate();
+    };
+  }, [dispatch]);
+
+  useEffect(() => {
+    if (!missionAnalysisWorker) return;
+
+    missionAnalysisWorker.onmessage = (event: MessageEvent<MissionThread[] | { error: string }>) => {
+      const data = event.data;
+      if (data && typeof data === 'object' && 'error' in data) {
+        dispatch({ type: 'ANALYSIS_ERROR', payload: { message: `Worker error: ${data.error}` } });
+      } else {
+        dispatch({ type: 'FINISH_ANALYSIS', payload: { threads: data as MissionThread[], placedEntities: state.placedEntities } });
+      }
+    };
+    missionAnalysisWorker.onerror = (error) =>
+      dispatch({ type: 'ANALYSIS_ERROR', payload: { message: `Worker failed: ${error.message}` } });
+  }, [missionAnalysisWorker, state.placedEntities, dispatch]);
+
+  useEffect(() => {
+    if (state.isAnalysisOverlayVisible && missionAnalysisWorker) {
+      dispatch({ type: 'START_ANALYSIS' });
+      missionAnalysisWorker.postMessage({
+        entities: state.placedEntities,
+        disabledSystemIds: state.disabledSystemIds,
+      });
+    }
+  }, [state.disabledSystemIds, state.isAnalysisOverlayVisible, state.placedEntities, missionAnalysisWorker, dispatch]);
+
+  return { missionAnalysisWorker, workerInitFailed };
+};

--- a/hooks/useTimeControls.ts
+++ b/hooks/useTimeControls.ts
@@ -1,0 +1,50 @@
+import { useState, useCallback, useEffect, useRef, useContext } from 'react';
+import { AppContext } from '../state/appState';
+
+export const useTimeControls = () => {
+  const { dispatch } = useContext(AppContext);
+  const [timeMultiplier, setTimeMultiplier] = useState(1);
+  const [isPaused, setIsPaused] = useState(true);
+  const animationFrameId = useRef<number | null>(null);
+  const lastFrameTime = useRef<number>(Date.now());
+
+  const togglePause = useCallback(() => setIsPaused(p => !p), []);
+  const setMultiplier = useCallback((speed: number) => {
+    setTimeMultiplier(speed);
+    setIsPaused(false);
+  }, []);
+
+  useEffect(() => {
+    if (isPaused) {
+      if (animationFrameId.current) cancelAnimationFrame(animationFrameId.current);
+      animationFrameId.current = null;
+      return;
+    }
+    const loop = () => {
+      const now = Date.now();
+      const deltaTime = now - lastFrameTime.current;
+      lastFrameTime.current = now;
+      const scaledDeltaTime = deltaTime * timeMultiplier;
+      dispatch({ type: 'TICK', payload: { scaledDeltaTime } });
+      animationFrameId.current = requestAnimationFrame(loop);
+    };
+    lastFrameTime.current = Date.now();
+    animationFrameId.current = requestAnimationFrame(loop);
+    return () => {
+      if (animationFrameId.current) cancelAnimationFrame(animationFrameId.current);
+    };
+  }, [isPaused, timeMultiplier, dispatch]);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.code === 'Space' && (e.target as HTMLElement).tagName !== 'INPUT' && (e.target as HTMLElement).tagName !== 'TEXTAREA') {
+        e.preventDefault();
+        togglePause();
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [togglePause]);
+
+  return { isPaused, timeMultiplier, togglePause, setMultiplier };
+};

--- a/tests/ts-loader.mjs
+++ b/tests/ts-loader.mjs
@@ -10,8 +10,13 @@ export async function resolve(specifier, context, defaultResolve) {
       return { url, shortCircuit: true };
     }
     if (specifier.startsWith('.') && !specifier.endsWith('.js') && !specifier.endsWith('.ts') && !specifier.endsWith('.tsx')) {
-      const url = new URL(specifier + '.ts', context.parentURL).href;
-      return { url, shortCircuit: true };
+      let url = new URL(specifier + '.ts', context.parentURL);
+      try {
+        await readFile(url);
+      } catch {
+        url = new URL(specifier + '.tsx', context.parentURL);
+      }
+      return { url: url.href, shortCircuit: true };
     }
     throw err;
   }

--- a/tests/worker-fallback.test.js
+++ b/tests/worker-fallback.test.js
@@ -12,6 +12,7 @@ const dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></
 globalThis.window = dom.window;
 globalThis.document = dom.window.document;
 globalThis.navigator = dom.window.navigator;
+globalThis.localStorage = { getItem: () => null, setItem: () => {}, removeItem: () => {} };
 
 // Make Worker throw during construction
 globalThis.Worker = class {


### PR DESCRIPTION
## Summary
- extract mission analysis worker setup into `useMissionAnalysisWorker`
- isolate time control state in `useTimeControls` and simplify `TimeControls`
- move sidebar width/collapse logic into reusable `SidebarLayout`
- streamline `App` to compose new hooks and layout

## Testing
- `npm test` *(fails: Fallback message should render)*

------
https://chatgpt.com/codex/tasks/task_e_689e9e24a26083288b5fbb3e28370e5a