### PR TITLE
Fix analysis worker failure fallback

### DIFF
--- a/components/Map.tsx
+++ b/components/Map.tsx
@@ -177,10 +177,10 @@ export const MapComponent = forwardRef<MapRef, MapComponentProps>(({
   const entityMap = useMemo(() => new Map(entities.map(e => [e.instanceId, e])), [entities]);
 
   return (
-    <div 
-        ref={mapWrapperRef} 
-        className="w-full h-full relative" 
-        style={{ backgroundColor: '#f8fafc' }}
+    <div
+        ref={mapWrapperRef}
+        className="w-full h-full relative"
+        style={{ width: '100%', height: '100%', position: 'relative', backgroundColor: '#f8fafc' }}
         onContextMenu={(e) => e.preventDefault()}
         onMouseMove={handleMouseMove}
     >

--- a/components/SidebarLayout.tsx
+++ b/components/SidebarLayout.tsx
@@ -61,7 +61,10 @@ export const SidebarLayout: React.FC<SidebarLayoutProps> = ({ onNewEntity, onEdi
   ].join(' ');
 
   return (
-    <div className={rootClasses}>
+    <div
+      className={rootClasses}
+      style={{ display: 'flex', height: '100vh', overflow: 'hidden' }}
+    >
       <Sidebar
         width={sidebarWidth}
         isCollapsed={isSidebarCollapsed}
@@ -70,7 +73,10 @@ export const SidebarLayout: React.FC<SidebarLayoutProps> = ({ onNewEntity, onEdi
         onEditEntity={onEditEntity}
       />
       {!isSidebarCollapsed && <ResizeHandle onMouseDown={handleMouseDown} />}
-      <main className="flex-1 h-full min-w-0 relative">
+      <main
+        className="flex-1 h-full min-w-0 relative"
+        style={{ flex: 1, height: '100%', minWidth: 0, position: 'relative' }}
+      >
         {children}
       </main>
     </div>

--- a/hooks/useMissionAnalysisWorker.ts
+++ b/hooks/useMissionAnalysisWorker.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useLayoutEffect } from 'react';
 import type { AppState, AppAction } from '../state/appState';
 import type { MissionThread } from '../types';
 
@@ -9,10 +9,14 @@ export const useMissionAnalysisWorker = (
   const [missionAnalysisWorker, setMissionAnalysisWorker] = useState<Worker | null>(null);
   const [workerInitFailed, setWorkerInitFailed] = useState(false);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     let worker: Worker | null = null;
     try {
-      worker = new Worker(new URL('../services/missionAnalysis.worker.ts', import.meta.url), { type: 'module' });
+      const WorkerCtor = (globalThis as any).Worker;
+      if (!WorkerCtor) {
+        throw new Error('Web Workers are not supported');
+      }
+      worker = new WorkerCtor(new URL('../services/missionAnalysis.worker.ts', import.meta.url), { type: 'module' });
       setMissionAnalysisWorker(worker);
     } catch (error) {
       console.error('Failed to create mission analysis worker:', error);
@@ -35,8 +39,10 @@ export const useMissionAnalysisWorker = (
         dispatch({ type: 'FINISH_ANALYSIS', payload: { threads: data as MissionThread[], placedEntities: state.placedEntities } });
       }
     };
-    missionAnalysisWorker.onerror = (error) =>
+    missionAnalysisWorker.onerror = (error) => {
       dispatch({ type: 'ANALYSIS_ERROR', payload: { message: `Worker failed: ${error.message}` } });
+      setWorkerInitFailed(true);
+    };
   }, [missionAnalysisWorker, state.placedEntities, dispatch]);
 
   useEffect(() => {

--- a/index.html
+++ b/index.html
@@ -2,11 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta http-equiv="Content-Security-Policy" content="worker-src 'self' blob:;">
     <title>OpsCanvas: Interactive Wargame Map</title>
-    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://cdn.tailwindcss.com" defer></script>
     <style>
       @keyframes pulse-slow {
         50% {
@@ -93,10 +91,10 @@
       }
 
     </style>
-  <link rel="stylesheet" href="/index.css">
+  <link rel="stylesheet" href="./index.css">
   </head>
   <body class="bg-slate-100">
     <div id="root"></div>
-    <script type="module" src="/index.tsx"></script>
+    <script type="module" src="./index.tsx"></script>
   </body>
 </html>

--- a/tests/index-css.test.js
+++ b/tests/index-css.test.js
@@ -6,6 +6,6 @@ const css = fs.readFileSync('index.css', 'utf8');
 assert.ok(css.trim().length > 0, 'index.css should not be empty');
 
 const html = fs.readFileSync('index.html', 'utf8');
-assert.ok(html.includes('<link rel="stylesheet" href="/index.css">'), 'index.html should reference index.css');
+assert.ok(/<link rel="stylesheet" href="\.?\/index.css">/.test(html), 'index.html should reference index.css');
 
 console.log('index.css link and content test passed.');

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import { defineConfig, loadEnv } from 'vite';
 export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
     return {
+      base: './',
       define: {
         'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
         'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)


### PR DESCRIPTION
## Summary
- improve worker initialization logic to use runtime Worker constructor and mark init failures
- surface worker error events and flag failures to show the UI fallback message
- serve built assets from relative paths so the UI loads when hosted in a subdirectory
- defer Tailwind CDN script so a slow external fetch doesn't block initial render
- remove restrictive CSP meta and add inline layout fallbacks so the map renders even if Tailwind fails

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ea546af8c83289ba45d81aee24592